### PR TITLE
ENG-1870 add seo-friendly titles to all doc pages

### DIFF
--- a/pages/guides/1password-setup.mdx
+++ b/pages/guides/1password-setup.mdx
@@ -1,3 +1,7 @@
+---
+title: 1Password Business Setup
+---
+
 import { Steps, Tabs } from "nextra/components";
 
 # 1Password Business Setup

--- a/pages/guides/_meta.ts
+++ b/pages/guides/_meta.ts
@@ -1,5 +1,5 @@
 export default {
-  "1password-setup": "1Password Business Setup",
-  "jumpcloud-setup": "JumpCloud MDM Setup",
+  "1password-setup": "1Password Business setup",
+  "jumpcloud-setup": "JumpCloud MDM setup",
   "hardening-kubernetes": "Hardening Kubernetes",
 };

--- a/pages/guides/hardening-kubernetes/deploying-falco.mdx
+++ b/pages/guides/hardening-kubernetes/deploying-falco.mdx
@@ -1,3 +1,7 @@
+---
+title: Deploying Falco
+---
+
 import { Steps } from "nextra/components";
 
 # Deploying Falco

--- a/pages/guides/hardening-kubernetes/deploying-tailscale-proxy.mdx
+++ b/pages/guides/hardening-kubernetes/deploying-tailscale-proxy.mdx
@@ -1,3 +1,7 @@
+---
+title: Deploying Tailscale Proxy
+---
+
 # Deploying Tailscale Proxy
 
 This guide will explain how to set up a Tailscale proxy on Kubernetes. This setup will allow users within the Tailscale network (`tailnet`) to access services running on a Kubernetes cluster. This is useful for internal applications or testing environments that shouldn't be publicly exposed.

--- a/pages/guides/jumpcloud-setup.mdx
+++ b/pages/guides/jumpcloud-setup.mdx
@@ -1,3 +1,7 @@
+---
+title: JumpCloud MDM Setup
+---
+
 import { Callout, Steps } from "nextra/components";
 
 # JumpCloud MDM Setup

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,3 +1,7 @@
+---
+title: Introduction
+---
+
 # Introduction
 
 Welcome to Oneleet's documentation. Here you'll find guides on how to set up Oneleet's security modules as well as guides for hardening your existing setup.

--- a/pages/integrations/aws.mdx
+++ b/pages/integrations/aws.mdx
@@ -1,3 +1,7 @@
+---
+title: Amazon Web Services (AWS)
+---
+
 # Amazon Web Services (AWS)
 
 ## Setup

--- a/pages/integrations/azure.mdx
+++ b/pages/integrations/azure.mdx
@@ -1,3 +1,7 @@
+---
+title: Microsoft Azure
+---
+
 # Microsoft Azure
 
 ## Setup

--- a/pages/integrations/cloudflare.mdx
+++ b/pages/integrations/cloudflare.mdx
@@ -1,3 +1,7 @@
+---
+title: Cloudflare
+---
+
 # Cloudflare
 
 ## Setup

--- a/pages/integrations/github.mdx
+++ b/pages/integrations/github.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub
+---
+
 # GitHub
 
 ## Setup

--- a/pages/integrations/gitlab.mdx
+++ b/pages/integrations/gitlab.mdx
@@ -1,3 +1,7 @@
+---
+title: Gitlab
+---
+
 # Gitlab
 
 ## Setup

--- a/pages/integrations/gitlab.mdx
+++ b/pages/integrations/gitlab.mdx
@@ -1,8 +1,8 @@
 ---
-title: Gitlab
+title: GitLab
 ---
 
-# Gitlab
+# GitLab
 
 ## Setup
 To setup the GitLab integration, navigate to the **Integrations > Add integration > GitLab** and click **Continue**.

--- a/pages/integrations/google-cloud-platform.mdx
+++ b/pages/integrations/google-cloud-platform.mdx
@@ -1,3 +1,7 @@
+---
+title: Google Cloud Platform (GCP)
+---
+
 # Google Cloud Platform
 
 ## Setup

--- a/pages/integrations/google-workspace.mdx
+++ b/pages/integrations/google-workspace.mdx
@@ -1,3 +1,7 @@
+---
+title: Google Workspace
+---
+
 # Google Workspace
 
 ## Setup

--- a/pages/integrations/jumpcloud.mdx
+++ b/pages/integrations/jumpcloud.mdx
@@ -1,3 +1,7 @@
+---
+title: Jumpcloud
+---
+
 # Jumpcloud
 
 ## Setup

--- a/pages/integrations/jumpcloud.mdx
+++ b/pages/integrations/jumpcloud.mdx
@@ -1,8 +1,8 @@
 ---
-title: Jumpcloud
+title: JumpCloud
 ---
 
-# Jumpcloud
+# JumpCloud
 
 ## Setup
 To setup the Jumpcloud integration, navigate to the **Integrations > Add integration > Jumpcloud** and click **Continue**.

--- a/pages/integrations/mezmo.mdx
+++ b/pages/integrations/mezmo.mdx
@@ -1,3 +1,7 @@
+---
+title: Mezmo
+---
+
 # Mezmo
 
 ## Setup

--- a/pages/integrations/microsoft365.mdx
+++ b/pages/integrations/microsoft365.mdx
@@ -1,3 +1,7 @@
+---
+title: Microsoft 365
+---
+
 # Microsoft 365
 
 ## Setup

--- a/pages/integrations/supabase.mdx
+++ b/pages/integrations/supabase.mdx
@@ -1,3 +1,7 @@
+---
+title: Supabase
+---
+
 # Supabase
 
 ## Setup

--- a/pages/integrations/vercel.mdx
+++ b/pages/integrations/vercel.mdx
@@ -1,3 +1,7 @@
+---
+title: Vercel
+---
+
 # Vercel
 
 ## Setup

--- a/pages/oneleet-agent/_meta.ts
+++ b/pages/oneleet-agent/_meta.ts
@@ -1,7 +1,7 @@
 export default {
-  "general-privacy": "General & Privacy",
+  "general-privacy": "General & privacy",
   setup: "Setup",
-  "data-collection": "Data Collection",
+  "data-collection": "Data collection",
   troubleshooting: "Troubleshooting",
-  faq: "Frequently Asked Questions",
+  faq: "Frequently asked questions",
 };

--- a/pages/oneleet-agent/data-collection.mdx
+++ b/pages/oneleet-agent/data-collection.mdx
@@ -1,5 +1,5 @@
 ---
-title: Oneleet agent data collection
+title: Oneleet Agent data collection
 ---
 
 import { Tabs } from "nextra/components";

--- a/pages/oneleet-agent/data-collection.mdx
+++ b/pages/oneleet-agent/data-collection.mdx
@@ -1,3 +1,7 @@
+---
+title: Oneleet agent data collection
+---
+
 import { Tabs } from "nextra/components";
 import { Callout } from "nextra/components";
 
@@ -5,7 +9,7 @@ import { Callout } from "nextra/components";
   The Oneleet Agent is currently invite-only. If you'd like to start using it, please contact us via your dedicated Slack Connect channel with us.
 </Callout>
 
-# Data Collection
+# Data collection
 
 The Oneleet Agent collects data from your device for continuous monitoring and security. The data collected includes:
 

--- a/pages/oneleet-agent/faq.mdx
+++ b/pages/oneleet-agent/faq.mdx
@@ -1,3 +1,7 @@
+---
+title: Oneleet agent FAQ
+---
+
 import { Callout } from "nextra/components";
 
 <Callout type="warning">

--- a/pages/oneleet-agent/faq.mdx
+++ b/pages/oneleet-agent/faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: Oneleet agent FAQ
+title: Oneleet Agent FAQ
 ---
 
 import { Callout } from "nextra/components";

--- a/pages/oneleet-agent/general-privacy.mdx
+++ b/pages/oneleet-agent/general-privacy.mdx
@@ -1,10 +1,14 @@
+---
+title: Oneleet agent general & privacy
+---
+
 import { Callout } from "nextra/components";
 
 <Callout type="warning">
   The Oneleet Agent is currently invite-only. If you'd like to start using it, please contact us via your dedicated Slack Connect channel with us.
 </Callout>
 
-# General & Privacy
+# General & privacy
 
 The Oneleet Agent leverages [osquery](https://osquery.io/)'s powerful SQL-like interface to gather system information, allowing security-aware teams to query real-time data such as hardware specifications, firewall information, and session locking settings. This granular visibility helps organizations quickly identify potential security threats and compliance violations, while the Agent's lightweight design ensures minimal impact on system performance.
 

--- a/pages/oneleet-agent/general-privacy.mdx
+++ b/pages/oneleet-agent/general-privacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Oneleet agent general & privacy
+title: Oneleet Agent general & privacy
 ---
 
 import { Callout } from "nextra/components";

--- a/pages/oneleet-agent/setup.mdx
+++ b/pages/oneleet-agent/setup.mdx
@@ -1,5 +1,5 @@
 ---
-title: Oneleet agent setup
+title: Oneleet Agent setup
 ---
 
 import { Callout } from "nextra/components";

--- a/pages/oneleet-agent/setup.mdx
+++ b/pages/oneleet-agent/setup.mdx
@@ -1,3 +1,7 @@
+---
+title: Oneleet agent setup
+---
+
 import { Callout } from "nextra/components";
 import { Tabs } from "nextra/components";
 

--- a/pages/oneleet-agent/troubleshooting.mdx
+++ b/pages/oneleet-agent/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Oneleet agent troubleshooting
+title: Oneleet Agent troubleshooting
 ---
 
 import { Tabs } from "nextra/components";

--- a/pages/oneleet-agent/troubleshooting.mdx
+++ b/pages/oneleet-agent/troubleshooting.mdx
@@ -1,3 +1,7 @@
+---
+title: Oneleet agent troubleshooting
+---
+
 import { Tabs } from "nextra/components";
 import { Steps } from 'nextra/components'
 import { Callout } from "nextra/components";

--- a/pages/penetration-testing/_meta.ts
+++ b/pages/penetration-testing/_meta.ts
@@ -1,11 +1,11 @@
 export default {
-  ptaas: "Penetration Testing as a Service (PtaaS)",
-  "services": "Pentesting Services",
-  "pentesting-classification": "Types of Pentests",
-  "process-overview": "Process Overview",
+  ptaas: "Penetration testing as a service (PtaaS)",
+  "services": "Pentesting services",
+  "pentesting-classification": "Types of pentests",
+  "process-overview": "Process overview",
   "documents": "Documents",
-  "final-report": "Penetration Test Report",
+  "final-report": "Penetration test report",
   "findings-decisions": "Remediation",
   "pci-dss": "PCI DSS",
-  "faq": "Frequently Asked Questions"
+  "faq": "Frequently asked questions"
 };

--- a/pages/penetration-testing/documents.mdx
+++ b/pages/penetration-testing/documents.mdx
@@ -1,4 +1,8 @@
-# Penetration Test Documents
+---
+title: Penetration test documents
+---
+
+# Penetration test documents
 
 At Oneleet, we offer several types of documents during the penetration testing process.
 

--- a/pages/penetration-testing/faq.mdx
+++ b/pages/penetration-testing/faq.mdx
@@ -1,3 +1,7 @@
+---
+title: Penetration test FAQ
+---
+
 # Frequently Asked Questions
 
 ### Does a Penetration Test at Oneleet include DDoS?

--- a/pages/penetration-testing/final-report.mdx
+++ b/pages/penetration-testing/final-report.mdx
@@ -1,6 +1,10 @@
+---
+title: Penetration test report
+---
+
 import { Callout } from "nextra/components";
 
-# Penetration Test Report
+# Penetration test report
 
 The findings from our penetration test form the core of the report you'll receive. Key elements include:
 

--- a/pages/penetration-testing/findings-decisions.mdx
+++ b/pages/penetration-testing/findings-decisions.mdx
@@ -1,3 +1,7 @@
+---
+title: Penetration test findings
+---
+
 # Remediation
 
 After receiving the penetration test report, there are several steps you can take, such as remediation, accepting the risk, or rejecting the findings.

--- a/pages/penetration-testing/pci-dss.mdx
+++ b/pages/penetration-testing/pci-dss.mdx
@@ -1,4 +1,8 @@
-# PCI DSS Penetration Test
+---
+title: PCI DSS Penetration test
+---
+
+# PCI DSS Penetration test
 
 If you hired Oneleet for a PCI DSS penetration test, there will be a few minor differences compared to our regular penetration testing process. The primary objectives of the PCI DSS penetration test are to:
 

--- a/pages/penetration-testing/pentesting-classification/_meta.ts
+++ b/pages/penetration-testing/pentesting-classification/_meta.ts
@@ -1,4 +1,4 @@
 export default {
-    "access-level": "Black, Grey and White-box",
-    "attack-vector": "Internal and External"
+    "access-level": "Black, grey and white-box",
+    "attack-vector": "Internal and external"
   }

--- a/pages/penetration-testing/pentesting-classification/access-level.mdx
+++ b/pages/penetration-testing/pentesting-classification/access-level.mdx
@@ -1,3 +1,7 @@
+---
+title: Access level
+---
+
 import { Callout } from "nextra/components";
 
 # Black, Grey and White-box Penetration Testing

--- a/pages/penetration-testing/pentesting-classification/attack-vector.mdx
+++ b/pages/penetration-testing/pentesting-classification/attack-vector.mdx
@@ -1,4 +1,8 @@
-# Internal and External Penetration Testing
+---
+title: Internal and external penetration testing
+---
+
+# Internal and external penetration testing
 
 Sometimes, there’s also a distinction made between internal and external penetration testing. 
 If the previous Black/Grey/White categorizes tests by what the tester knows/can access, the Internal/External one categorizes tests by where the testing originates.

--- a/pages/penetration-testing/process-overview.mdx
+++ b/pages/penetration-testing/process-overview.mdx
@@ -1,4 +1,8 @@
-# Penetration Testing High-level Overview
+---
+title: Penetration testing overview
+---
+
+# Penetration testing high-level overview
 
 ![](/penetration-testing/process.png)
 

--- a/pages/penetration-testing/ptaas.mdx
+++ b/pages/penetration-testing/ptaas.mdx
@@ -1,4 +1,8 @@
-# Penetration Testing as a Service (PtaaS)
+---
+title: Penetration testing as a service (PtaaS)
+---
+
+# Penetration testing as a service (PtaaS)
 
 ## About Us
 

--- a/pages/penetration-testing/ptaas.mdx
+++ b/pages/penetration-testing/ptaas.mdx
@@ -1,8 +1,8 @@
 ---
-title: Penetration testing as a service (PtaaS)
+title: Penetration testing as a Service (PtaaS)
 ---
 
-# Penetration testing as a service (PtaaS)
+# Penetration testing as a Service (PtaaS)
 
 ## About Us
 

--- a/pages/penetration-testing/services/_meta.ts
+++ b/pages/penetration-testing/services/_meta.ts
@@ -1,4 +1,4 @@
 export default {
-    "areas": "Pentesting Engagements",
-    "packages": "Pentesting Packages"
+    "areas": "Pentesting engagements",
+    "packages": "Pentesting packages"
 }

--- a/pages/penetration-testing/services/areas.mdx
+++ b/pages/penetration-testing/services/areas.mdx
@@ -1,4 +1,8 @@
-# Penetration Test Engagements
+---
+title: Penetration test engagements
+---
+
+# Penetration test engagements
 
 Oneleet’s penetration testing team specializes in several types of engagements, including:
 

--- a/pages/penetration-testing/services/packages.mdx
+++ b/pages/penetration-testing/services/packages.mdx
@@ -1,4 +1,8 @@
-# Penetration Test Packages
+---
+title: Penetration test packages
+---
+
+# Penetration test packages
 
 At Oneleet, we offer **3** different types of penetration test packages.
 

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -58,19 +58,20 @@ const config = {
     const url =
       "https://docs.oneleet.com" +
       (defaultLocale === locale ? asPath : `/${locale}${asPath}`);
+    const title = frontMatter.title
+      ? `${frontMatter.title} - Oneleet Docs`
+      : "Oneleet Docs";
 
     return (
       <>
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta property="og:url" content={url} />
-        <meta
-          property="og:title"
-          content={frontMatter.title || "Oneleet Docs"}
-        />
+        <meta property="og:title" content={title} />
         <meta
           property="og:description"
           content={frontMatter.description || "Oneleet Docs"}
         />
+        <title>{title}</title>
       </>
     );
   },


### PR DESCRIPTION
## Problem

- https://linear.app/oneleet/issue/ENG-1870/investigate-missing-titles-in-nextra-documentation

## Solution

- Add SEO-friendly postfix of `- Oneleet Docs`
- Add titles for all documentation pages
- Fix some casing issues

![Screenshot 2025-01-07 at 14 55 28](https://github.com/user-attachments/assets/0ffa14cf-74d0-43d7-9dbc-30fc7adcbaf5)
