### PR TITLE
Remove availability note for Zoom

### DIFF
--- a/pages/integrations/zoom.mdx
+++ b/pages/integrations/zoom.mdx
@@ -4,10 +4,6 @@ title: Zoom
 
 # Zoom
 
-## Availability
-
-This integration is not yet generally available. We are in the process of working with Zoom to get their approval.
-
 ## Add the integration
 
 To add the Zoom integration on the Oneleet platform:


### PR DESCRIPTION
## Problem

We're no longer waiting for Zoom to approve our integration

## Solution

Remove this note from the docs

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Availability" section from the Zoom integration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->