### PR TITLE
ENG-3223: Document GitHub permission update for Dependabot alerts

### DIFF
--- a/pages/integrations/github.mdx
+++ b/pages/integrations/github.mdx
@@ -36,18 +36,6 @@ To resolve this, you'll need to upgrade your GitHub organization to the paid Tea
 
 ## Updates
 
-### 2025-07-10
-
-#### What's changing?
-
-We're updating our GitHub integration to support user access reviews. As part of this change, we will soon require the following **additional permissions**:
-
-- Read access to **"Members"**
-
-#### Action required
-
-You should have received a GitHub notification prompting you to accept new permissions for the **Oneleet** app. Please accept the permissions to enable user access reviews for GitHub on Oneleet.
-
 ### 2025-08-14
 
 #### What's changing?
@@ -59,3 +47,15 @@ We're updating our GitHub integration to monitor Dependabot vulnerability alerts
 #### Action required
 
 You should have received a GitHub notification prompting you to accept new permissions for the **Oneleet** app. Please accept the permissions to enable Dependabot alert monitoring on Oneleet.
+
+### 2025-07-10
+
+#### What's changing?
+
+We're updating our GitHub integration to support user access reviews. As part of this change, we will soon require the following **additional permissions**:
+
+- Read access to **"Members"**
+
+#### Action required
+
+You should have received a GitHub notification prompting you to accept new permissions for the **Oneleet** app. Please accept the permissions to enable user access reviews for GitHub on Oneleet.


### PR DESCRIPTION
## Problem

https://linear.app/oneleet/issue/ENG-3223/lightdash-dependabot-monitor-shows-no-applicable-assets

Our GitHub app doesn't have permission to read Dependabot alerts.

## Solution

Document this update. We'll send an email notification after this is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * GitHub integration docs updated with a 2025-08-14 entry introducing monitoring of Dependabot vulnerability alerts.
  * Added new required GitHub permission: Read access to “Dependabot alerts.”
  * Updated setup instructions to enable Dependabot alert monitoring in Oneleet.
  * Notes that monitored scope shifts from user access reviews to Dependabot alerts while retaining the 2025-07-10 entry about Members permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->