### PR TITLE
Add troubleshooting advice for agent failing to start on Ubuntu

### DIFF
--- a/pages/oneleet-agent/troubleshooting.mdx
+++ b/pages/oneleet-agent/troubleshooting.mdx
@@ -303,4 +303,6 @@ Replace `/path/to/oneleet-agent` as follows:
 - If you installed the `.deb`, use the path to the `oneleet-agent` binary (`/usr/bin/oneleet-agent` by default).
 - If you're using the AppImage, use the path to the `.AppImage` file.
 
+Once you've created the file, apply it to your system with `sudo systemctl reload apparmor.service`.
+
 See [this answer on Ask Ubuntu](https://askubuntu.com/a/1528215) for additional context.


### PR DESCRIPTION
## Problem

https://linear.app/oneleet/issue/ENG-3156/codspeed-getting-a-chrome-sandbox-permissions-error-when-trying-to-run

The agent, like all Electron apps without special support baked in by Canonical, will always crash on the latest Ubuntu. See the ticket for more context.

## Solution

Add troubleshooting advice to the docs for the agent failing to start on Ubuntu. We should fix this with an update to the Linux agent, but pointing to this advice should work as a band-aid until we resume agent development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Ubuntu-specific troubleshooting for Oneleet Agent startup failures when Chrome/Chromium sandboxing is blocked by AppArmor.
  * Included an example AppArmor policy and manual installation steps, with guidance to adjust the agent binary path for .deb vs AppImage installs.
  * Clarified error symptoms and step-by-step resolution; added a reference to an external Ask Ubuntu resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->