### PR TITLE
ENG-3372: Document oneleet-ignore tag for DigitalOcean

### DIFF
--- a/pages/integrations/digitalocean.mdx
+++ b/pages/integrations/digitalocean.mdx
@@ -1,0 +1,9 @@
+---
+title: DigitalOcean
+---
+
+# DigitalOcean
+
+## Ignoring DigitalOcean droplets
+
+If you want to prevent certain DigitalOcean droplets from appearing in your Oneleet account and counting toward monitors, tag them with `oneleet-ignore`.


### PR DESCRIPTION
## Problem

https://linear.app/oneleet/issue/ENG-3372/modx-allow-ignoring-digitalocean-droplets-with-tags-like-for-aws

We haven't documented this yet.

## Solution

Add a very brief note to a new DigitalOcean docs page.
