### PR TITLE
Add Linear integration documentation

### DIFF
--- a/pages/integrations/_meta.ts
+++ b/pages/integrations/_meta.ts
@@ -9,6 +9,7 @@ export default {
   "google-cloud-platform": "Google Cloud Platform",
   "google-workspace": "Google Workspace",
   jumpcloud: "Jumpcloud",
+  linear: "Linear",
   mezmo: "Mezmo",
   microsoft365: "Microsoft 365",
   supabase: "Supabase",

--- a/pages/integrations/linear.mdx
+++ b/pages/integrations/linear.mdx
@@ -1,0 +1,42 @@
+---
+title: Linear
+---
+
+# Linear
+
+## Overview
+
+The Linear integration connects your Linear workspace to Oneleet, syncing **users** and **teams** as assets. This enables Oneleet to monitor user access and team configuration across your project management platform.
+
+### What does Oneleet monitor?
+
+- **Users** — workspace members, including roles (Admin, Guest, Member), activity status, and profile details
+- **Teams** — team membership, webhook configurations, and owner assignments
+
+## Setup
+
+To set up the Linear integration, navigate to **Integrations > Add integration > Linear** and click **Continue**.
+
+Oneleet uses OAuth to connect to the Linear API. Click the **Connect** button to start the OAuth authorization flow.
+
+### Required permissions
+
+The OAuth flow requests the following Linear scopes:
+
+- `read` — read access to Linear data
+- `write` — write access to Linear data
+- `issues:create` — create issues in Linear
+- `comments:create` — create comments in Linear
+
+### Connection process
+
+1. Click **Connect** on the integration setup form
+2. You will be redirected to Linear to authorize Oneleet
+3. Grant the requested permissions
+4. Linear will redirect you back to Oneleet
+
+Oneleet will use the authorized user's email as the connection identifier.
+
+### Reconnecting
+
+If you need to refresh your OAuth credentials, navigate to the integration settings and click **Reconnect** to re-authorize.


### PR DESCRIPTION
## Summary
- Add documentation page for the Linear integration
- Covers OAuth setup flow, required scopes (read, write, issues:create, comments:create)
- Documents monitored asset types: users and teams
- Add Linear to the integrations sidebar navigation

## Test plan
- [ ] Verify page renders correctly with `npm run dev`
- [ ] Confirm sidebar navigation order is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linear integration to sync users and teams into Oneleet with OAuth-based authentication.

* **Documentation**
  * Added setup guide for Linear integration, including step-by-step connection instructions, required OAuth scopes, and reconnection procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->