### PR TITLE
Add Slack integration documentation

### DIFF
--- a/pages/integrations/_meta.ts
+++ b/pages/integrations/_meta.ts
@@ -11,6 +11,7 @@ export default {
   jumpcloud: "Jumpcloud",
   mezmo: "Mezmo",
   microsoft365: "Microsoft 365",
+  slack: "Slack",
   supabase: "Supabase",
   vercel: "Vercel",
   zoom: "Zoom",

--- a/pages/integrations/slack.mdx
+++ b/pages/integrations/slack.mdx
@@ -16,7 +16,7 @@ The Slack integration connects your Slack workspace or Enterprise Grid organizat
 
 ## Setup
 
-To set up the Slack integration, navigate to **Integrations > Add integration > Slack** and click **Continue**.
+To set up the Slack integration, navigate to **Integrations > Add integration > Slack**.
 
 Oneleet uses OAuth to connect to the Slack API. You will first select your Slack plan type, then complete the OAuth authorization flow.
 

--- a/pages/integrations/slack.mdx
+++ b/pages/integrations/slack.mdx
@@ -36,6 +36,7 @@ Select the plan type that matches your Slack workspace.
 You must be a **workspace owner** or **administrator** to authorize the integration.
 
 **Bot scopes:**
+- `users:read` — read user list
 - `channels:read` — read channel information
 - `groups:read` — read private channel information
 - `team:read` — read workspace information

--- a/pages/integrations/slack.mdx
+++ b/pages/integrations/slack.mdx
@@ -1,0 +1,72 @@
+---
+title: Slack
+---
+
+# Slack
+
+## Overview
+
+The Slack integration connects your Slack workspace or Enterprise Grid organization to Oneleet, syncing **channels**, **users**, and **guest users** as assets. This enables Oneleet to monitor user access, 2FA status, and channel configuration.
+
+### What does Oneleet monitor?
+
+- **Channels** — public and private channels (excluding archived channels)
+- **Users** — workspace members, including roles (Admin, Owner, Primary Owner) and 2FA status
+- **Guest users** — restricted and ultra-restricted users (multi-workspace guests, single-channel guests)
+
+## Setup
+
+To set up the Slack integration, navigate to **Integrations > Add integration > Slack** and click **Continue**.
+
+Oneleet uses OAuth to connect to the Slack API. You will first select your Slack plan type, then complete the OAuth authorization flow.
+
+### Selecting your plan type
+
+Oneleet supports two Slack plan types with different permission requirements:
+
+- **Standard** (Free, Pro, Business+)
+- **Enterprise Grid**
+
+Select the plan type that matches your Slack workspace.
+
+### Required permissions
+
+#### Standard plan
+
+You must be a **workspace owner** or **administrator** to authorize the integration.
+
+**Bot scopes:**
+- `channels:read` — read channel information
+- `groups:read` — read private channel information
+- `team:read` — read workspace information
+- `chat:write` — send messages (for notifications)
+- `app_mentions:read` — read app mentions
+- `mpim:read` — read multi-person DM channels
+
+**User scopes:**
+- `users:read` — read user list
+- `users:read.email` — read user email addresses
+
+#### Enterprise Grid
+
+You must be an **Organization Owner** or have both **Organization User Admin** and **Channels Admin** roles.
+
+**Bot scopes** (in addition to standard scopes):
+- `admin.teams:read` — list all teams in the organization
+- `admin.users:read` — list all organization users
+
+**User scopes:**
+- `users:read` — read user list
+- `users:read.email` — read user email addresses
+
+### Connection process
+
+1. Select your Slack plan type (Standard or Enterprise Grid)
+2. Click **Connect**
+3. You will be redirected to Slack to authorize Oneleet
+4. Grant the requested permissions
+5. Slack will redirect you back to Oneleet
+
+### Reconnecting
+
+If you need to refresh your OAuth credentials, navigate to the integration settings, select your plan type, and click **Reconnect**.

--- a/pages/integrations/slack.mdx
+++ b/pages/integrations/slack.mdx
@@ -51,13 +51,13 @@ You must be a **workspace owner** or **administrator** to authorize the integrat
 
 You must be an **Organization Owner** or have both **Organization User Admin** and **Channels Admin** roles.
 
-**Bot scopes** (in addition to standard scopes):
-- `admin.teams:read` — list all teams in the organization
-- `admin.users:read` — list all organization users
+**Bot scopes**: same as **Standard** scopes
 
 **User scopes:**
 - `users:read` — read user list
 - `users:read.email` — read user email addresses
+- `admin.users:read`— read users across workspaces in the Slack Enterprise Grid organization
+- `admin.teams:read` — read teams across workspaces in the Slack Enterprise Grid organization
 
 ### Connection process
 


### PR DESCRIPTION
## Summary
- Add documentation page for the Slack integration
- Covers both Standard and Enterprise Grid plan types with different permission requirements
- Documents OAuth scopes (bot and user scopes) for each plan type
- Documents monitored asset types: channels, users, guest users
- Add Slack to the integrations sidebar navigation

## Test plan
- [ ] Verify page renders correctly with `npm run dev`
- [ ] Confirm sidebar navigation order is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack integration is available, syncing channels (excluding archived), workspace users (with roles and 2FA status), and guest users (restricted and ultra‑restricted).

* **Documentation**
  * Added a Slack guide covering setup via Integrations > Add integration, OAuth connection flow, Standard vs. Enterprise Grid requirements (bot/user scopes), connection steps, and reconnect instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->